### PR TITLE
add interface to query system and block status

### DIFF
--- a/src/main/java/com/baidu/xuperunion/api/XuperClient.java
+++ b/src/main/java/com/baidu/xuperunion/api/XuperClient.java
@@ -209,4 +209,36 @@ public class XuperClient {
         Common.checkResponseHeader(response.getHeader(), "query transaction");
         return response.getBlock();
     }
+
+    /**
+     * getSystemStatus get system status contains all blockchains
+     * 
+     * @return instance of SystemsStatus
+     * @throws Exception
+     */
+    public XchainOuterClass.SystemsStatus getSystemStatus() throws Exception {
+        XchainOuterClass.CommonIn request =  XchainOuterClass.CommonIn.newBuilder()
+                .setHeader(Common.newHeader())
+                .build();
+        XchainOuterClass.SystemsStatusReply response = blockingClient.getSystemStatus(request);
+        Common.checkResponseHeader(response.getHeader(), "query system status");
+        return response.getSystemsStatus();
+    }
+
+    /**
+     * getBlockchainStatus get the status of given blockchain
+     * 
+     * @param chainName the name of blockchain
+     * @return instance of BCStatus
+     * @throws Exception
+     */
+    public XchainOuterClass.BCStatus getBlockchainStatus(String chainName) throws Exception {
+        XchainOuterClass.BCStatus request =  XchainOuterClass.BCStatus.newBuilder()
+                .setHeader(Common.newHeader())
+                .setBcname(chainName)
+                .build();
+        XchainOuterClass.BCStatus bcs = blockingClient.getBlockChainStatus(request);
+        Common.checkResponseHeader(bcs.getHeader(), "query blockchain status");
+        return bcs;
+    }
 }

--- a/src/test/java/com/baidu/xuperunion/api/XuperClientTest.java
+++ b/src/test/java/com/baidu/xuperunion/api/XuperClientTest.java
@@ -115,6 +115,39 @@ public class XuperClientTest {
     }
 
     @Test
+    public void getSystemStatus() throws Exception {
+        XchainOuterClass.SystemsStatus status = client.getSystemStatus();
+        assertEquals(1, status.getBcsStatusCount());
+        System.out.println("blockchain count:" + status.getBcsStatusCount());
+        // 遍历所有的链
+        for (int i = 0; i < status.getBcsStatusCount(); i++) {
+            XchainOuterClass.BCStatus bcs = status.getBcsStatusList().get(i);
+            // 打印链名
+            System.out.println("blockchain " + i + ", name=" + bcs.getBcname());
+            // 链上当前主干高度
+            System.out.println("---- Height: " + bcs.getMeta().getTrunkHeight());
+            // 链上最新的块ID
+            System.out.println("---- TipBlockId: " + Hex.toHexString(bcs.getMeta().getTipBlockid().toByteArray()));
+            // 链上创世块ID
+            System.out.println("---- RootBlockId: " + Hex.toHexString(bcs.getMeta().getRootBlockid().toByteArray()));
+        }
+    }
+
+    @Test
+    public void getBlockchainStatus() throws Exception {
+        XchainOuterClass.BCStatus bcs = client.getBlockchainStatus("xuper");
+        assertEquals("xuper", bcs.getBcname());
+        // 打印链名
+        System.out.println("blockchain name=" + bcs.getBcname());
+        // 链上当前主干高度
+        System.out.println("---- Height: " + bcs.getMeta().getTrunkHeight());
+        // 链上最新的块ID
+        System.out.println("---- TipBlockId: " + Hex.toHexString(bcs.getMeta().getTipBlockid().toByteArray()));
+        // 链上创世块ID
+        System.out.println("---- RootBlockId: " + Hex.toHexString(bcs.getMeta().getRootBlockid().toByteArray()));
+    }
+
+    @Test
     public void apiExample() throws Exception {
         createContractAccount();
         transfer();
@@ -124,5 +157,6 @@ public class XuperClientTest {
         queryTx();
         queryBlock();
         getBalance();
+        getSystemStatus();
     }
 }


### PR DESCRIPTION
This PR add two interface for status query:

1. `getSystemStatus`: get system status contains all blockchains
2. `getBlockchainStatus`: get the status of given blockchain