### PR TITLE
修复 参数值为 ""时,设置了为null,造成签名和实际传输的数据不同,验签失败

### DIFF
--- a/src/main/java/com/baidu/xuper/api/TxEncoder.java
+++ b/src/main/java/com/baidu/xuper/api/TxEncoder.java
@@ -179,11 +179,14 @@ class TxEncoder {
             if (pb.getArgsCount() != 0) {
                 TreeMap<String, ByteString> margs = new TreeMap<>();
                 for (Map.Entry<String, ByteString> entry : pb.getArgsMap().entrySet()) {
+                    /*
                     if (entry.getValue().isEmpty()) {
                         margs.put(entry.getKey(), null);
                     } else {
                         margs.put(entry.getKey(), entry.getValue());
-                    }
+                    }*/
+                    //修复 参数值为 ""时,设置了为null,造成签名和实际传输的数据不同,验签失败
+                    margs.put(entry.getKey(), entry.getValue());
                 }
                 m.put("args", margs);
             }


### PR DESCRIPTION
## Description

What is the purpose of the change?
修复 参数值为 ""时,设置了为null,造成签名和实际传输的数据不同,验签失败

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)





## How Has This Been Tested?
![11111111](https://user-images.githubusercontent.com/4935705/142621181-6a58814b-cedf-4185-87c2-5f00ef78a737.png)
![22222222](https://user-images.githubusercontent.com/4935705/142621192-574eb6eb-0dbd-45b5-9ac4-299660cebda0.png)


